### PR TITLE
Add PDL implementation with identical tests

### DIFF
--- a/lib/Math/3Space/PDL.pm
+++ b/lib/Math/3Space/PDL.pm
@@ -1,0 +1,633 @@
+package Math::3Space::PDL;
+
+# VERSION
+# ABSTRACT: 3D Coordinate math with an intuitive cross-space mapping API
+
+use strict;
+use warnings;
+use Carp;
+use PDL::Lite;
+use PDL::Constants qw(PI);
+use constant NV_tolerance => 1e-14;
+use Scalar::Util qw(refaddr);
+
+use overload
+  '""' => sub { $_[0]{pdl}.'' },
+  '==' => sub { (refaddr($_[0])//0) == (refaddr($_[1])//0) }, # reference equality
+  ;
+
+=head1 SYNOPSIS
+
+  use Math::3Space::PDL 'vec3', 'space';
+
+  my $boat= space;
+  my $sailor= space($boat);
+  my $dock= space;
+
+  # boat moves, carrying sailor with it
+  $boat->translate(0,0,1)->rotate(.001, [0,1,0]);
+
+  # sailor walks onto the dock
+  $sailor->translate(10,0,0);
+  $sailor->reparent($dock);
+
+  # The boat and dock are both floating
+  for ($dock, $boat) {
+    $_->translate(rand(.1), rand(.1), rand(.1))
+      ->rotate(rand(.001), [1,0,0])
+      ->rotate(rand(.001), [0,0,1]);
+  }
+
+  # Sailor is holding a rope at 1,1,1 relative to themself.
+  # Where is the end of the rope in boat-space?
+  my $rope_end= vec3(1,1,1);
+  $sailor->unproject_inplace($rope_end);
+  $dock->unproject_inplace($rope_end);
+  $boat->project_inplace($rope_end);
+
+  # Do the same thing in bulk with fewer calculations
+  my $sailor_to_boat= space($boat)->reparent($sailor);
+  @boat_points= $sailor_to_boat->project(@sailor_points);
+
+  # Interoperate with OpenGL
+  @float16= $boat->get_gl_matrix;
+
+=head1 DESCRIPTION
+
+This module implements the sort of 3D coordinate space math that would typically be done using
+a 4x4 matrix, but instead uses a 3x4 matrix composed of axis vectors C<xv>, C<yv>, C<zv>
+(i.e. vectors that point along the axes of the coordinate space) plus an origin point.
+This results in significantly fewer math operations needed to project points, and gives you a
+more useful mental model to work with, like being able to see which direction the coordinate
+space is "facing", or which way is "up".
+
+The coordinate spaces track their L</parent> coordinate space, so you can perform advanced
+projections from a space inside a space out to a different space inside a space inside a space
+without thinking about the details.
+
+The coordinate spaces can be exported as 4x4 matrices for use with OpenGL or other common 3D
+systems.
+
+Specifically, this module uses L<PDL> for all its data storage and
+manipulation, unlike L<Math::3Space> which uses its own custom XS
+vector code.
+
+=cut
+
+{ package Math::3Space::PDL::Exports;
+	use Exporter::Extensible -exporter_setup => 1;
+	require Math::3Space::PDL::Vector;
+	*vec3= *Math::3Space::PDL::Vector::vec3;
+	*space= *Math::3Space::PDL::space;
+	export 'vec3', 'space';
+}
+sub import { shift; Math::3Space::PDL::Exports->import_into(scalar(caller), @_) }
+*_parseargs = \&Math::3Space::PDL::Vector::_parseargs;
+
+sub parent { $_[0]{parent} }
+
+=head1 CONSTRUCTOR
+
+=head2 space
+
+  $space= Math::3Space::PDL::space();
+  $space= Math::3Space::PDL::space($parent);
+  $space= $parent->space;
+
+Construct a space (optionally within C<$parent>) initialized to an identity:
+
+  origin => [0,0,0],
+  xv     => [1,0,0],
+  yv     => [0,1,0],
+  zv     => [0,0,1],
+
+=cut
+
+my $identity = pdl(
+  [1,0,0],
+  [0,1,0],
+  [0,0,1],
+  [0,0,0], # origin
+);
+sub space {
+  my ($parent) = @_;
+  my $self = bless {parent=>$parent}, __PACKAGE__;
+  $self->{pdl} = $identity->copy;
+  $self->{n_parents} = defined $parent ? $parent->{n_parents}+1 : 0;
+  $self->{is_normal} = 1;
+  $self;
+}
+
+=head2 new
+
+  $space= Math::3Space::PDL->new(%attributes)
+
+Initialize a space from raw attributes.
+
+=head1 ATTRIBUTES
+
+=head2 parent
+
+Optional reference to parent coordinate space.  The origin and each of the axis vectors are
+described in terms of the parent coordinate space.  A parent of C<undef> means the space is
+described in terms of global absolute coordinates.
+
+=head2 parent_count
+
+Number of parent coordinate spaces above this one, i.e. the "depth" of this node in the
+hierarchy.
+
+=cut
+
+sub parent_count {
+  my ($space) = @_;
+  $space->_recache_parent;
+  $space->{n_parents};
+}
+
+=head2 origin
+
+The C<< [x,y,z] >> vector (point) of this space's origin in terms of the parent space.
+
+=head2 xv
+
+The C<< [x,y,z] >> vector of the X axis (often named "I" in math text)
+
+=head2 yv
+
+The C<< [x,y,z] >> vector of the Y axis (often named "J" in math text)
+
+=head2 zv
+
+The C<< [x,y,z] >> vector of the Z axis (often named "K" in math text)
+
+=cut
+
+for (['xv', 0], ['yv', 1], ['zv', 2], ['origin', 3]) {
+  my ($name, $offset) = @$_;
+  no strict 'refs';
+  *$name = sub {
+    my ($space, @vals) = @_;
+    my $vec = @vals ? _parseargs(@vals) : undef;
+    my $slice = $space->{pdl}->slice(",($offset)");
+    return Math::3Space::PDL::Vector::vec3($slice->sever) if !defined $vec;
+    $slice .= $vec;
+    $space->{is_normal} = -1 if $offset < 3;
+    $space;
+  };
+}
+
+=head2 is_normal
+
+Returns true if all axis vectors are unit-length and orthogonal to each other.
+
+=cut
+
+sub is_normal {
+  return $_[0]{is_normal} if $_[0]{is_normal} >= 0;
+  my $pdl = $_[0]{pdl}->slice(',0:2');
+  $_[0]{is_normal} = 0;
+  return 0 if !$pdl->ipow(2)->sumover->approx(1, NV_tolerance)->all;
+  my @vecs = $pdl->dog;
+  for (map [$_-1,$_], 0..$#vecs) {
+    return 0 if !$vecs[$_->[0]]->inner($vecs[$_->[1]])->approx(0, NV_tolerance);
+  }
+  $_[0]{is_normal} = 1;
+}
+
+=head1 METHODS
+
+=head2 clone
+
+Return a new space with the same values, including same parent.
+
+=cut
+
+sub clone {
+  my ($space) = @_;
+  bless {pdl=>$space->{pdl}->copy, parent=>$space->{parent}, n_parents=>$space->{n_parents}}, __PACKAGE__;
+}
+
+=head2 space
+
+Return a new space describing an identity, with the current object as its parent.
+
+=head2 reparent
+
+Project this coordinate space into a different parent coordinate space.  After the projection,
+this space still refers to the same absolute global coordinates as it did before, but it is
+described in terms of a different parent coordinate space.
+
+For example, in a 3D game where a player is riding in a vehicle, the parent of the player's
+3D space is the vehicle, and the parent space of the vehicle is the ground.
+If the player jumps off the vehicle, you would call C<< $player->reparent($ground); >> to keep
+the player at their current position, but begin describing them in terms of the ground.
+
+Setting C<$parent> to C<undef> means "global coordinates".
+
+=cut
+
+sub _recache_parent {
+  my ($space_orig) = @_;
+  my ($depth, $space, $prev, %seen) = 0;
+  my $cur = $space_orig;
+  while ($cur) {
+    $prev = $space;
+    croak("'parent' is not a Math::3Space : $cur")
+      if !UNIVERSAL::isa($cur, __PACKAGE__);
+    my $cur_parent = ($space = $cur)->{parent};
+    $cur->{parent} = undef;
+    if ($prev) {
+      $prev->{parent} = $space;
+      if (++$depth > 964) { # Check for cycles in the graph
+        croak("Cycle detected in space->parent graph")
+          if $seen{refaddr $space};
+        $seen{refaddr $space} = 1; # signal that we've been here with any pointer value
+      }
+    }
+    $cur = $cur_parent;
+  }
+  for ($space = $space_orig; $space; $space = $space->{parent}) {
+    $space->{n_parents} = $depth--;
+  }
+}
+
+sub _project_space { # args opposite order from XS
+  my ($space, $parent) = @_;
+  my ($space_pdl, $parent_pdl) = map $_->{pdl}, $space, $parent;
+  my ($parent_basis, $parent_origin) = map $parent_pdl->slice($_), ',0:2', ',3';
+  $space_pdl->slice(',3') -= $parent_origin;
+  $space_pdl .= $space_pdl x $parent_basis->transpose;
+  @$space{qw(parent n_parents)} = ($parent, $parent->{n_parents}+1);
+}
+
+sub _unproject_space { # args opposite order from XS
+  my ($space, $parent) = @_;
+  my ($space_pdl, $parent_pdl) = map $_->{pdl}, $space, $parent;
+  my ($parent_basis, $parent_origin) = map $parent_pdl->slice($_), ',0:2', ',3';
+  $space_pdl .= $space_pdl x $parent_basis;
+  $space_pdl->slice(',3') += $parent_origin;
+  @$space{qw(parent n_parents)} = @$parent{qw(parent n_parents)};
+}
+
+sub reparent {
+  my ($space, $parent) = @_;
+  if (defined $parent) {
+    $parent->_recache_parent;
+    my $cur = $parent;
+    while ($cur) {
+      croak "Attempt to create a cycle: new 'parent' is a child of this space" if $cur == $space;
+      $cur = $cur->parent;
+    }
+  }
+  return $space if $space->{parent} == $parent;
+  # Walk back the stack of parents until it has fewer parents than 'space'.
+  # This way space->parent has a chance to be 'common_parent'.
+  my $common_parent = $parent;
+  $common_parent = $common_parent->parent
+    while $common_parent && $common_parent->{n_parents} >= $space->{n_parents};
+  # Now unproject 'space' from each of its parents until its parent is 'common_parent'.
+  while ($space->{n_parents} && !($space->parent == $common_parent)) {
+    # Map 'space' out to be a sibling of its parent
+    _unproject_space($space, $space->parent);
+    # if 'space' reached the depth of common_parent+1 and the loop didn't stop,
+    # then it wasn't actually the parent they have in common, yet.
+    $common_parent = $common_parent->parent
+      if $common_parent && $common_parent->{n_parents} + 1 == $space->{n_parents};
+  }
+  # At this point, 'space' is either a root 3Space, or 'common_parent' is its parent.
+  # If the common parent is the original 'parent', then we're done.
+  return $space if ($parent//0) == ($common_parent//0);
+  # Calculate an equivalent space to 'parent' at this parent depth.
+  croak("assertion failed: parent != NULL") if !defined $parent;
+  my $sp_tmp = $parent->clone;
+  _unproject_space($sp_tmp, $sp_tmp->{parent}),
+    until ($sp_tmp->{parent}//0) == ($common_parent//0);
+  # sp_tmp is now equivalent to projecting through the chain from common_parent to parent
+  _project_space($space, $sp_tmp);
+  $space->{parent} = $parent;
+  $space->{n_parents} = $parent->{n_parents} + 1;
+  # Note that any space which has 'space' as a parent will now have an invalid n_parents
+  # cache, which is why those caches need rebuilt before calling this function.
+  $space;
+}
+
+=head2 project
+
+  @local_points= $space->project( @parent_points );
+  @parent_points= $space->unproject( @local_points );
+  @local_vectors= $space->project_vector( @parent_vectors );
+  $space->project_inplace( @points );
+  $space->project_vector_inplace( @vectors );
+
+Project one or more points (or vectors) into (or out of) this coordinate space.
+
+The C<project> and C<unproject> methods operate on points, meaning that they subtract or add
+the Space's C<origin> to the result in addition to (un)projecting along each of the
+C<(xv, yv, zv)> axes.
+
+The C<_vector> variants do not add/subtract L</origin>, so vectors that were acting as
+directional indicators will still be indicating that direction afterward regardless of this
+space's C<origin>.
+
+The C<_inplace> variants modify the points or vectors and return C<$self> for method chaining.
+
+Each parameter is another vector to process.  The projected vectors are returned in a list the
+same length and format as the list passed to this function, e.g. if you supply
+L<Math::3Space::PDL::Vector> objects you get back C<Vector> objects.  If you supply C<[x,y,z]>
+arrayrefs you get back arrayrefs.
+
+Variants:
+
+=over
+
+=item project_vector_inplace
+
+=item project_inplace
+
+=item unproject_vector_inplace
+
+=item unproject_inplace
+
+=cut
+
+for (['project_vector_inplace', 0], ['project_inplace', 1], ['unproject_vector_inplace', 2], ['unproject_inplace', 3]) {
+  my ($name, $ix) = @$_;
+  no strict 'refs';
+  *$name = sub {
+    my ($space, @vals) = @_;
+    my $space_mat = $space->{pdl}->slice(',0:2');
+    $space_mat = $space_mat->transpose if $ix <= 1;
+    my $origin = ($ix % 2) ? $space->{pdl}->slice(',(3)') : undef;
+    for my $val (@vals) {
+      my $vec = _parseargs($val);
+      $vec -= $origin if $ix == 1;
+      $vec .= $vec x $space_mat;
+      $vec += $origin if $ix == 3;
+      if (ref($val) eq 'ARRAY') {
+        my @list = $vec->list;
+        @list = @list[0..$#$val] if @$val > @list;
+        @$val = @list;
+      }
+    }
+    $space;
+  };
+}
+
+=item project_vector
+
+=item project
+
+=item unproject_vector
+
+=item unproject
+
+=cut
+
+for (['project_vector', 0], ['project', 1], ['unproject_vector', 2], ['unproject', 3]) {
+  my ($name, $ix) = @$_;
+  no strict 'refs';
+  *$name = sub {
+    my ($space, @vals) = @_;
+    my $space_mat = $space->{pdl}->slice(',0:2');
+    $space_mat = $space_mat->transpose if $ix <= 1;
+    my $origin = ($ix % 2) ? $space->{pdl}->slice(',(3)') : undef;
+    my @ret;
+    for my $val (@vals) {
+      my $vec = _parseargs($val)->copy;
+      $vec -= $origin if $ix == 1;
+      $vec .= $vec x $space_mat;
+      $vec += $origin if $ix == 3;
+      push @ret, ref($val) eq 'ARRAY' ? [$vec->list] :
+        UNIVERSAL::isa($val, 'PDL') ? $vec :
+        Math::3Space::PDL::Vector::vec3($vec);
+    }
+    @ret == 1 ? $ret[0] : @ret;
+  };
+}
+
+=back
+
+=head2 normalize
+
+Ensure that the C<xv>, C<yv>, and C<zv> axis vectors are unit length and orthogonal to
+each other, like proper eigenvectors.  The algorithm is:
+
+  * make zv a unit vector
+  * xv = yv cross zv, and make it a unit vector
+  * yv = xv cross zv, and make it a unit vector
+
+=head2 translate
+
+  $space->translate($x, $y, $z);
+  $space->translate([$x, $y, $z]);
+  $space->translate($vec);
+  # alias 'tr'
+  $space->tr(...);
+
+Translate the origin of the coordinate space, in terms of parent coordinates.
+
+=for Pod::Coverage tr
+
+=cut
+
+sub translate {
+  my ($space, @vals) = @_;
+  my $vec = _parseargs(@vals);
+  my $origin = $space->{pdl}->slice(",(3)");
+  $origin += $vec;
+  $space;
+}
+*tr = \&translate;
+
+=head2 travel
+
+  $space->travel($x, $y, $z);
+  $space->travel([$x, $y, $z]);
+  $space->travel($vec);
+  # alias 'go'
+  $space->go(...);
+
+Translate the origin of the coordinate space in terms of its own coordinates.
+e.g. if your L</zv> vector is being used as "forward", you can make an object travel
+forward with C<< $space->travel(0,0,1) >>.
+
+=for Pod::Coverage go
+
+=cut
+
+sub travel {
+  my ($space, @vals) = @_;
+  my $vec = _parseargs(@vals);
+  my $origin = $space->{pdl}->slice(",(3)");
+  $origin += $vec x $space->{pdl}->slice(",0:2");
+  $space;
+}
+*go = \&travel;
+
+=head2 set_scale
+
+  $space->set_scale($uniform);
+  $space->set_scale($x, $y, $z);
+  $space->set_scale([$x, $y, $z]);
+  $space->set_scale($vector);
+
+Reset the scale of the axes of this space.  For instance, C<< ->set_scale(1) >> normalizes the
+vectors so that the scale is identical to the parent coordinate space.
+
+=head2 scale
+
+  $space->scale($uniform);
+  $space->scale($x, $y, $z);
+  $space->scale([$x, $y, $z]);
+  $space->scale($vector);
+
+Scale the axes of this space by a multiplier to the existing scale.
+
+=cut
+
+sub scale {
+  my ($space, @vals) = @_;
+  if (!ref $vals[0] and 0+@vals == 1) {
+    @vals = (@vals) x 3;
+  } elsif (!ref $vals[0] and @vals < 3) {
+    $vals[$_] //= $vals[0] for 1..2;
+  }
+  my $vec = _parseargs(@vals);
+  $space->{pdl}->slice(",0:2") *= $vec->transpose;
+  $space->{is_normal} = -1;
+  $space;
+}
+
+=head2 rotate
+
+  $space->rotate($revolutions, $x, $y, $z);
+  $space->rotate($revolutions, [$x, $y, $z]);
+  $space->rotate($revolutions, $vec);
+
+  $space->rot($revolutions => ...); # alias for 'rotate'
+
+  $space->rot_x($revolutions);      # optimized for specific vectors
+  $space->rot_xv($revolutions);
+
+This rotates the C<xv>, C<yv>, and C<zv> axes by an angle around some other vector.  The angle
+is measured in revolutions rather than degrees or radians, so C<1> is a full rotation back to
+where you started, and .25 is a quarter rotation.  The vector is defined in terms of the parent
+coordinate space.  If you want to rotate around an arbitrary vector defined in *local*
+coordinates, just unproject it out to the parent coordinate space first.
+
+=cut
+
+my $ZEROVEC = pdl(0,0,0);
+my $X_UNITVEC = pdl(1,0,0);
+my $Y_UNITVEC = pdl(0,1,0);
+sub rotate {
+  my ($space, $angle, @vals) = @_;
+  my $vec = _parseargs(@vals);
+  croak "Can't rotate around vector with 0 magnitude" if $ZEROVEC->eq($vec)->all;
+  my $zv = $vec->norm;
+  my $xv = $X_UNITVEC->crossp($zv);
+  $xv = $Y_UNITVEC->crossp($zv) if $xv->ipow(2)->sumover < NV_tolerance;
+  my $yv = $zv->crossp($xv);
+  my $rot_mat = pdl($xv, $yv, $zv)->norm;
+  my $space_mat = $space->{pdl}->slice(',0:2');
+  my $projected = $space_mat x $rot_mat->transpose;
+  $angle *= 2 * PI;
+  my ($s, $c) = (sin $angle, cos $angle);
+  my ($mo1, $mo2) = map $projected->slice($_), 0, 1;
+  my ($tmp1, $tmp2) = ($c * $mo1 - $s * $mo2, $s * $mo1 + $c * $mo2);
+  $mo1 .= $tmp1;
+  $mo2 .= $tmp2;
+  $space_mat .= $projected x $rot_mat;
+  $space;
+}
+*rot = \&rotate;
+
+=pod
+
+The following (more efficient) variants are available for rotating about the parent's axes or
+this space's own axes:
+
+=for Pod::Coverage rot
+
+=over
+
+=item rot_x
+
+=item rot_y
+
+=item rot_z
+
+=cut
+
+for (['rot_x', 0], ['rot_y', 1], ['rot_z', 2]) {
+  my ($name, $ix) = @$_;
+  no strict 'refs';
+  my ($ofs1, $ofs2) = (($ix+1)%3, ($ix+2)%3);
+  *$name = sub {
+    my ($space, $angle) = @_;
+    $angle *= 2 * PI;
+    my ($s, $c) = (sin $angle, cos $angle);
+    my $pdl = $space->{pdl}->slice(',0:2');
+    my ($mo1, $mo2) = map $pdl->slice($_), $ofs1, $ofs2;
+    my ($tmp1, $tmp2) = ($c * $mo1 - $s * $mo2, $s * $mo1 + $c * $mo2);
+    $mo1 .= $tmp1;
+    $mo2 .= $tmp2;
+    $space;
+  };
+}
+
+=item rot_xv
+
+=item rot_yv
+
+=item rot_zv
+
+=cut
+
+for (['rot_xv', 0], ['rot_yv', 1], ['rot_zv', 2]) {
+  my ($name, $ix) = @$_;
+  no strict 'refs';
+  my ($ofs1, $ofs2) = (($ix+1)%3, ($ix+2)%3);
+  *$name = sub {
+    my ($space, $angle) = @_;
+    return $space->rotate($angle, $space->{pdl}->slice(",($ix)")) if !$space->is_normal;
+    $angle *= 2 * PI;
+    my ($s, $c) = (sin $angle, cos $angle);
+    my $space_mat = $space->{pdl}->slice(',0:2');
+    if ($ix == 0) {
+      my $rotated = pdl([0,$c,$s], [0,-$s,$c]); # yv, zv
+      $space_mat->slice(',1:2') .= ($rotated x $space_mat);
+    } elsif ($ix == 1) {
+      my $rotated = pdl([$c,0,-$s], [$s,0,$c]); # xv, zv
+      $space_mat->slice(',0:2:2') .= ($rotated x $space_mat);
+    } else {
+      my $rotated = pdl([$c,$s,0], [-$s,$c,0]); # xv, yv
+      $space_mat->slice(',0:1') .= ($rotated x $space_mat);
+    }
+    $space;
+  };
+}
+
+=back
+
+=head2 get_gl_matrix
+
+  @float16= $space->get_gl_matrix();
+  $space->get_gl_matrix($buffer);
+
+Get an OpenGL-compatible 16-element array representing a 4x4 matrix that would perform the same
+projection as this space.  This can either be returned as 16 perl floats, or written into a
+packed buffer of 16 doubles.
+
+=cut
+
+my $GL_app = pdl(0,0,0,1)->transpose;
+sub get_gl_matrix {
+  my ($space) = @_;
+  my @floats = $space->{pdl}->append($GL_app)->list;
+  return @floats if @_ < 2;
+  $_[1] = pack(d16 => @floats);
+}
+
+1;

--- a/lib/Math/3Space/PDL/Vector.pm
+++ b/lib/Math/3Space/PDL/Vector.pm
@@ -1,0 +1,291 @@
+package Math::3Space::PDL::Vector;
+
+# VERSION
+# ABSTRACT: Object wrapping a PDL buffer of three NVs
+
+use strict; use warnings;
+use Exporter 'import';
+our @EXPORT_OK= qw( vec3 );
+
+use PDL::Lite;
+use Config;
+use Carp;
+
+use overload '""' => sub { $_[0]{pdl}.'' };
+
+=head1 SYNOPSIS
+
+  use Math::3Space::PDL::Vector 'vec3';
+
+  $vec= vec3(1,2,3);
+
+  say $vec->x;
+  $vec->x(12);
+
+  ($x, $y, $z)= $vec->xyz;
+  $vec->set(4,3,2);
+
+  $dot_product= vec3(0,1,0)->dot(1,0,0);
+  $cross_product= vec3(1,0,0)->cross(0,0,1);
+
+=head1 DESCRIPTION
+
+This object is a blessed hash-ref with a PDL buffer of double-precision
+numbers. The zero-th dimension is always length 3.  For more general
+vector classes, see many other modules on CPAN.  This is simply an
+efficient way for the 3Space object to pass vectors around without fully
+allocating Perl structures for them.
+
+=head1 CONSTRUCTOR
+
+=head2 vec3
+
+  $vec= vec3($x, $y, $z);
+  $vec= vec3([ $x, $y, $z ]);
+  $vec2= vec3($vec);
+
+=cut
+
+sub vec3 {
+  __PACKAGE__->new(
+    (@_ == 1 && ref $_[0] && UNIVERSAL::isa($_[0], 'PDL')) ? $_[0] :
+    (@_ == 1 && ref $_[0] && UNIVERSAL::isa($_[0], __PACKAGE__)) ? $_[0]{pdl} :
+    @_ > 1 ? \@_ : @_
+  )
+}
+
+=head2 new
+
+  $vec= Math::3Space::PDL::Vector->new(); # 0,0,0
+  $vec= Math::3Space::PDL::Vector->new([ $x, $y, $z ]);
+  $vec= Math::3Space::PDL::Vector->new(x => $x, y => $y, z => $z);
+  $vec= Math::3Space::PDL::Vector->new({ x => $x, y => $y, z => $z });
+
+=cut
+
+sub _parseargs {
+  my ($x_or_vec, $y, $z) = @_;
+  if (defined $y) {
+    return pdl($x_or_vec, $y, $z);
+  } elsif (ref $x_or_vec eq 'ARRAY') {
+    return pdl($x_or_vec);
+  } elsif (ref $x_or_vec eq 'HASH') {
+    return pdl(@$x_or_vec{qw(x y z)});
+  } elsif (ref $x_or_vec and UNIVERSAL::isa($x_or_vec, 'PDL')) {
+    return $x_or_vec;
+  } elsif (ref $x_or_vec and UNIVERSAL::isa($x_or_vec, __PACKAGE__)) {
+    return $x_or_vec->{pdl};
+  } elsif (length($x_or_vec) == 3*$Config{nvsize}) {
+    my $type = PDL::Type->new($Config{nvsize} == 8 ? 'double' : $Config{nvsize} == 4 ? 'float' : die "Unknown NV size $Config{nvsize}");
+    my $vec = PDL->zeroes($type, 3);
+    ${$vec->get_dataref} = $x_or_vec;
+    $vec->upd_data;
+    return $vec;
+  } else {
+    croak "Can't handle ($x_or_vec, @{[$y//'undef']}, @{[$z//'undef']})";
+  }
+}
+
+sub new {
+  my ($class, @vals) = @_;
+  my $val;
+  if (!@vals) {
+    $val = [0,0,0];
+  } elsif (!(@vals % 2)) {
+    $val = {@vals};
+  } elsif (@vals != 1) {
+    croak "Expected even-length list or one element, got (@vals)";
+  } elsif (ref $vals[0] and ref $vals[0] ne 'ARRAY' and ref $vals[0] ne 'HASH' and !UNIVERSAL::isa($vals[0], 'PDL')) {
+    croak "Expected one hash- or array-ref, got (@vals)";
+  } else {
+    $val = $vals[0];
+  }
+  my $vec = _parseargs($val);
+  bless {pdl=>$vec}, $class;
+}
+
+=head1 ATTRIBUTES
+
+=head2 x
+
+Read/write 'x' field.
+
+=head2 y
+
+Read/write 'y' field.
+
+=head2 z
+
+Read/write 'z' field.
+
+=cut
+
+for (['x', 0], ['y', 1], ['z', 2]) {
+  my ($name, $offset) = @$_;
+  no strict 'refs';
+  *$name = sub {
+    my ($self, $val) = @_;
+    return $self->{pdl}->at($offset) if !defined $val;
+    $self->{pdl}->set($offset, $val);
+    $self;
+  };
+}
+
+=head2 xyz
+
+Return list of (x,y,z).
+
+=cut
+
+sub xyz {my ($self) = @_; $self->{pdl}->list;}
+
+=head2 magnitude
+
+  $mag= $vector->magnitude;
+  $vector->magnitude($new_length);
+
+Read/write length of vector.  Attempting to write to a vector with length 0 emits a warning and
+does nothing.
+
+=cut
+
+sub magnitude {
+  my ($self, $newval) = @_;
+  my $length = $self->{pdl}->ipow(2)->sumover->sqrt;
+  return $length if !defined $newval;
+  warn("Attempting to write to a vector with length 0"), return if !$length;
+  $self->{pdl} *= $newval / $length;
+  $self;
+}
+
+=head1 METHODS
+
+=head2 set
+
+  $vector->set($vec2);
+  $vector->set($x,$y,$z);
+  $vector->set([$x,$y,$z]);
+
+=head2 add
+
+  $vector->add($vec2);
+  $vector->add($x,$y);
+  $vector->add($x,$y,$z);
+  $vector->add([$x,$y,$z]);
+
+=head2 sub
+
+  $vector->sub($vec2);
+  $vector->sub($x,$y);
+  $vector->sub($x,$y,$z);
+  $vector->sub([$x,$y,$z]);
+
+=cut
+
+for ([qw(set assgn)], [qw(add plus)], [qw(sub minus)]) {
+  my ($name, $op) = @$_;
+  no strict 'refs';
+  *$name = sub {
+    my ($self, @vals) = @_;
+    if (!ref $vals[0]) {
+      $vals[$_] //= 0 for 1..2;
+    }
+    my $vec = _parseargs(@vals);
+    if ($op eq 'assgn') {
+      $vec->$op($self->{pdl});
+    } else {
+      $self->{pdl}->inplace->$op($vec);
+    }
+    $self;
+  };
+}
+
+=head2 scale
+
+  $vector->scale($scale); # x= y= z= $scale
+  $vector->scale($x, $y); # z= 1
+  $vector->scale($x, $y, $z);
+  $vector->scale([$x, $y, $z]);
+  $vector->scale($vec2);
+
+Multiply each component of the vector by a scalar.
+
+=cut
+
+sub scale {
+  my ($self, @vals) = @_;
+  if (!ref $vals[0] and 0+@vals == 1) {
+    @vals = (@vals) x 3;
+  } elsif (!ref $vals[0]) {
+    $vals[$_] //= 1 for 1..2;
+  }
+  my $vec = _parseargs(@vals);
+  $self->{pdl}->inplace;
+  $self->{pdl}->mult($vec);
+  $self;
+}
+
+=head2 dot
+
+  $prod= $vector->dot($vector2);
+  $prod= $vector->dot($x,$y,$z);
+  $prod= $vector->dot([$x,$y,$z]);
+
+Dot product with another vector.
+
+=cut
+
+sub dot {
+  my ($self, @vals) = @_;
+  my $vec = _parseargs(@vals);
+  $self->{pdl}->inner($vec);
+}
+
+=head2 cos
+
+  $cos= $vector->cos($vector2);
+  $cos= $vector->cos($x,$y,$z);
+  $cos= $vector->cos([$x,$y,$z]);
+
+Return the vector-cosine to the other vector.  This is the same as the dot product divided by
+the magnitudes of the vectors, or identical to the dot product when the vectors are unit-length.
+This dies if either vector is zero length (or too close to zero for available floating precision).
+
+=cut
+
+sub cos {
+  my ($self, @vals) = @_;
+  my $vec = _parseargs(@vals);
+  my $actual_dot_product = $self->{pdl}->inner($vec);
+  my ($abs2_1, $abs2_2) = map $_->ipow(2)->sumover, $self->{pdl}, $vec;
+  $actual_dot_product->divide($abs2_1->mult($abs2_2)->sqrt);
+}
+
+=head2 cross
+
+  $c= $a->cross($b);
+  $c= $a->cross($bx, $by, $bz);
+  $c= $a->cross([$bx, $by, $bz]);
+  $c->cross($a, $b);
+
+Return a new vector which is the cross product C<< A x B >>, or if called with 2 parameters
+assign the cross product to the object itself.
+
+=cut
+
+sub cross {
+  my ($self, @vals) = @_;
+  my ($vec, $vec2);
+  if (@vals == 2) {
+    ($vec, $vec2) = map _parseargs($_), @vals;
+  } else {
+    $vec = _parseargs(@vals);
+  }
+  if (defined $vec2) {
+    $self->{pdl} .= $vec->crossp($vec2);
+    return $self;
+  }
+  bless {pdl=>$self->{pdl}->crossp($vec)}, ref($self);
+}
+
+1;

--- a/t/02-vector-pdl.t
+++ b/t/02-vector-pdl.t
@@ -1,0 +1,52 @@
+use Test2::V0;
+BEGIN {eval {require PDL;1} or skip_all("No PDL")}
+use Math::3Space::PDL::Vector;
+
+*vec3= *Math::3Space::PDL::Vector::vec3;
+
+sub vec_check {
+	my ($x, $y, $z)= @_;
+	return object { call sub { [shift->xyz] }, [ float($x), float($y), float($z) ]; }
+}
+
+is( vec3(1,2,3),                       vec_check(1,2,3), 'basic ctor' );
+is( vec3(vec3(4,3,2)),                 vec_check(4,3,2), 'clone ctor' );
+
+is( vec3(5,5,5)->x(1)->y(4),           vec_check(1,4,5), 'x y z accessors' );
+is( [ vec3(5,5,5)->xyz ],              [5, 5, 5],        'read xyz accessor' );
+
+is( vec3(5,5,5)->set(1,2,3),           vec_check(1,2,3), 'set($x,$y,$z)' );
+is( vec3(1,0,0)->add(0,1,1),           vec_check(1,1,1), 'add(x,y,z)' );
+is( vec3(1,0,0)->add(1,1),             vec_check(2,1,0), 'add(x,y)' );
+is( vec3(1,0,0)->add([1,1,1]),         vec_check(2,1,1), 'add([x,y,z])' );
+is( vec3(1,0,0)->add(vec3(-1,-1,2)),   vec_check(0,-1,2),'add(vec)' );
+is( vec3(1,0,0)->sub(-1,0,-5),         vec_check(2,0,5), 'sub(x,y,z)' );
+is( vec3(1,1,1)->scale(2),             vec_check(2,2,2), 'scale(uniform)' );
+is( vec3(1,1,1)->scale(2,2),           vec_check(2,2,1), 'scale(x,y)' );
+is( vec3(1,1,1)->scale(2,2,2),         vec_check(2,2,2), 'scale(x,y,z)' );
+is( vec3(1,1,1)->scale(vec3(0,0,0)),   vec_check(0,0,0), 'scale(vec)' );
+
+is( vec3(5,0,0)->magnitude->sclr,      float(5),         'magnitude' );
+is( vec3(5,0,0)->magnitude(2),         vec_check(2,0,0), 'set magnitude' );
+
+is( vec3(1,0,0)->dot(0,5,0)->sclr,     float(0),         'dot orthogonal' );
+is( vec3(0,0,1)->dot(0,0,2)->sclr,     float(2),         'dot colinear' );
+is( vec3(0,2,0)->dot(0,-2,0)->sclr,    float(-4),        'dot opposite' );
+
+is( vec3(1,0,0)->cos(0,1,0)->sclr,     float(0),         'cos orthogonal' );
+is( vec3(1,1,1)->cos(1,1,1)->sclr,     float(1),         'cos colinear' );
+is( vec3(1,1,0)->cos(-1,-1,0)->sclr,   float(-1),        'cos opposite' );
+
+is( vec3(1,0,0)->cross([ 0,1,0 ]),     vec_check(0,0,1),  'X->cross(Y) = Z' );
+is( vec3(0,0,0)->cross([0,1,0], [0,0,1]), vec_check(1,0,0),  'Self= X cross Y' );
+
+sub M3V { 'Math::3Space::PDL::Vector' }
+is( M3V->new,                          vec_check(0,0,0), 'constructor defaults' );
+is( M3V->new(x => 1),                  vec_check(1,0,0), 'init x attr' );
+is( M3V->new(y => 1),                  vec_check(0,1,0), 'init y attr' );
+is( M3V->new(z => 1),                  vec_check(0,0,1), 'init z attr' );
+is( M3V->new({ x => 1 }),              vec_check(1,0,0), 'init x attr via hashref' );
+is( M3V->new({ y => 1 }),              vec_check(0,1,0), 'init y attr via hashref' );
+is( M3V->new({ z => 1 }),              vec_check(0,0,1), 'init z attr via hashref' );
+
+done_testing;

--- a/t/03-ctor-pdl.t
+++ b/t/03-ctor-pdl.t
@@ -1,0 +1,61 @@
+use Test2::V0;
+BEGIN {eval {require PDL;1} or skip_all("No PDL")}
+use Math::3Space::PDL 'space';
+
+sub check_vec {
+	my ($x, $y, $z)= @_;
+	return object { call sub { [shift->xyz] }, [ $x, $y, $z ]; }
+}
+
+is( Math::3Space::PDL::space(), object {
+	call xv     => check_vec(1, 0, 0);
+	call yv     => check_vec(0, 1, 0);
+	call zv     => check_vec(0, 0, 1);
+	call origin => check_vec(0, 0, 0);
+	call parent => undef;
+}, 'global ctor' );
+
+is space(), '
+[
+ [1 0 0]
+ [0 1 0]
+ [0 0 1]
+ [0 0 0]
+]
+', 'stringify';
+
+is( my $s1= space(), object {
+	call xv     => check_vec(1, 0, 0);
+	call yv     => check_vec(0, 1, 0);
+	call zv     => check_vec(0, 0, 1);
+	call origin => check_vec(0, 0, 0);
+	call parent => undef;
+}, 'imported ctor' );
+
+is( $s1->space, object {
+	call xv     => check_vec(1, 0, 0);
+	call yv     => check_vec(0, 1, 0);
+	call zv     => check_vec(0, 0, 1);
+	call origin => check_vec(0, 0, 0);
+	call parent => $s1;
+}, 'derived space' );
+
+my $s2= $s1->space->rotate(.5, [1,1,1]);
+is( $s2->clone, object {
+	call xv   => check_vec($s2->xv->xyz);
+	call yv   => check_vec($s2->yv->xyz);
+	call zv   => check_vec($s2->zv->xyz);
+	call parent => $s2->parent;
+	call parent_count => $s2->parent_count;
+}, 'clone' );
+
+# Test accessors
+for my $name (qw( origin xv yv zv )) {
+	my $m= $s1->can($name);
+	is( $s1->$m(1,2,3)->$m,   check_vec(1,2,3), "write $name (,,)" );
+	my $vec= $s1->$m;
+	is( $s1->$m([2,3,4])->$m, check_vec(2,3,4), "write $name [,,]" );
+	is( $s1->$m( $vec )->$m,  check_vec(1,2,3), "write $name vec()" );
+}
+
+done_testing;

--- a/t/04-transform-pdl.t
+++ b/t/04-transform-pdl.t
@@ -1,0 +1,150 @@
+use Test2::V0;
+BEGIN {eval {require PDL;1} or skip_all("No PDL")}
+use Math::3Space::PDL 'space', 'vec3';
+
+sub vec_check {
+	my ($x, $y, $z)= @_;
+	return object { call sub { [shift->xyz] }, [ float($x), float($y), float($z) ]; }
+}
+
+subtest translate => sub {
+	my $s1= space();
+	$s1->xv([2,0,0]); # just so move_rel is different from move
+	is( $s1->tr( 3,3,3), object { call origin => vec_check(3,3,3); }, 'translate(3,3,3)' );
+	is( $s1->tr(-1,0,1), object { call origin => vec_check(2,3,4); }, 'translate(-1,0,1)' );
+	
+	$s1= space();
+	$s1->xv([2,0,0]);
+	is( $s1->travel([1,1,1]), object { call origin => vec_check(2,1,1); }, 'travel(1,1,1)' );
+};
+
+subtest scale => sub {
+	my $s1= space();
+	is( $s1->scale(5), object {
+		call xv => vec_check(5,0,0);
+		call yv => vec_check(0,5,0);
+		call zv => vec_check(0,0,5);
+		call origin => vec_check(0,0,0);
+	}, 'scale(5)' );
+};
+
+subtest rotate => sub {
+	# Basic quarter rotations around each axis
+	# quarter rotation around X axis should leave y axis pointing at z
+	is( space->rot_x(.25), object {
+		call is_normal => T;
+		call xv => vec_check(1,0,0);
+		call yv => vec_check(0,0,1);
+		call zv => vec_check(0,-1,0);
+	}, 'rotate around parent X axis' );
+	# quarter rotation around Y axis should move z to point at x
+	is( space->rot_y(.25), object {
+		call is_normal => T;
+		call xv => vec_check(0,0,-1);
+		call yv => vec_check(0,1,0);
+		call zv => vec_check(1,0,0);
+	}, 'rotate around parent Y axis' );
+	# quarter rotation around Z axis should leave XV pointing at Y and YV pointing at -X
+	is( space->rot_z(.25), object {
+		call is_normal => T;
+		call xv => vec_check(0,1,0);
+		call yv => vec_check(-1,0,0);
+		call zv => vec_check(0,0,1);
+	}, 'rotate around parent Z axis' );
+	is( space->rot_x(.1)->rot_y(.4), object {
+		call is_normal => T;
+		call xv => vec_check(-0.80901699,0,-0.58778525);
+		call yv => vec_check(0.34549150,0.80901699,-0.47552825);
+		call zv => vec_check(0.47552825,-0.58778525,-0.65450849);
+	}, 'two non-right-angle rotations' );
+	
+	# Rotations of non-unit-length axis vectors:
+	# Ensure that magnitude is preserved and that they remain orthogonal.
+	my $s1= space->scale(2,3,4)->rot_x(.1)->rot_y(.4)->rot_z(.8);
+	is( $s1, object {
+		call is_normal => F;
+		call xv => object {
+		  call sub { shift->magnitude->sclr } => float(2);
+		  call sub { shift->dot($s1->yv)->sclr } => float(0);
+                };
+		call yv => object {
+		  call sub { shift->magnitude->sclr } => float(3);
+		  call sub { shift->dot($s1->zv)->sclr } => float(0);
+                };
+		call zv => object {
+		  call sub { shift->magnitude->sclr } => float(4);
+		  call sub { shift->dot($s1->xv)->sclr } => float(0);
+                };
+	}, 'rotate_x/y/z on scaled axes' );
+	
+	# Starting from the Identity, the self-relative rotations will have the same effect as the
+	# rotations around parent axes.
+	# quarter rotation around X axis should leave y axis pointing at z
+	is( space->rot_xv(.25), object {
+		call is_normal => T;
+		call xv => vec_check(1,0,0);
+		call yv => vec_check(0,0,1);
+		call zv => vec_check(0,-1,0);
+	}, 'rotate around own X axis, optimized' );
+	# quarter rotation around Y axis should move z to point at x
+	is( space->rot_yv(.25), object {
+		call is_normal => T;
+		call xv => vec_check(0,0,-1);
+		call yv => vec_check(0,1,0);
+		call zv => vec_check(1,0,0);
+	}, 'rotate around own Y axis, optimized' );
+	# quarter rotation around Z axis should leave XV pointing at Y and YV pointing at -X
+	is( space->rot_zv(.25), object {
+		call is_normal => T;
+		call xv => vec_check(0,1,0);
+		call yv => vec_check(-1,0,0);
+		call zv => vec_check(0,0,1);
+	}, 'rotate around own Z axis, optimized' );
+	# Now test the non-optimized code path when the axes are not normal eigenvectors.
+	is( space->scale(5)->rot_xv(.25), object {
+		call is_normal => F;
+		call xv => vec_check(5,0,0);
+		call yv => vec_check(0,0,5);
+		call zv => vec_check(0,-5,0);
+	}, 'rotate around own X axis' );
+	# quarter rotation around Y axis should move z to point at x
+	is( space->scale(5)->rot_yv(.25), object {
+		call is_normal => F;
+		call xv => vec_check(0,0,-5);
+		call yv => vec_check(0,5,0);
+		call zv => vec_check(5,0,0);
+	}, 'rotate around own Y axis' );
+	# quarter rotation around Z axis should leave XV pointing at Y and YV pointing at -X
+	is( space->scale(5)->rot_zv(.25), object {
+		call is_normal => F;
+		call xv => vec_check(0,5,0);
+		call yv => vec_check(-5,0,0);
+		call zv => vec_check(0,0,5);
+	}, 'rotate around own Z axis' );
+	
+	# Un-optimized rotations around an arbitrary axis
+	# 1/3 rotation around 1,1,1 should swap axes with each other.
+	is( space->rotate(1/3, [1,1,1]), object {
+		call is_normal => T;
+		call origin => vec_check(0,0,0);
+		call xv => vec_check(0,1,0);
+		call yv => vec_check(0,0,1);
+		call zv => vec_check(1,0,0);
+	}, 'rotate around (1,1,1)' );
+};
+
+subtest rotate_subspace => sub {
+  my $sp1= space->rot_z(.125);
+  my $sp2= $sp1->space->rot_z(.125);
+  my $sp3= $sp2->space->rot_z(.125);
+  my $sp4= $sp3->space->rot_z(.125);
+  is( $sp4, object {
+    call is_normal => T;
+    call origin => vec_check(0,0,0);
+    call xv => vec_check(0.70710678,0.70710678,0);
+    call yv => vec_check(-0.70710678,0.70710678,0);
+    call zv => vec_check(0,0,1);
+  }, 'rotate 4 times, each subspaced' );
+};
+
+done_testing;

--- a/t/05-parent-pdl.t
+++ b/t/05-parent-pdl.t
@@ -1,0 +1,81 @@
+use Test2::V0;
+BEGIN {eval {require PDL;1} or skip_all("No PDL")}
+use Math::3Space::PDL 'space', 'vec3';
+
+sub vec_check {
+	my ($x, $y, $z)= @_;
+	return object { call sub { [shift->xyz] }, [ float($x), float($y), float($z) ]; }
+}
+
+subtest parent_graph_checks => sub {
+	# detect cycles
+	my @spaces= (space->rot(.25, [1,1,1]));
+	push @spaces, $spaces[-1]->space for 1..100;
+	is( $spaces[-1]->parent_count, 100, 'tree is 100 deep' );
+	is( $spaces[$_]->parent_count, $_, "parent count of $_" )
+		for 62..66; # cross threshold where it starts checking for cycles
+
+	is( eval { $spaces[-5]->reparent($spaces[-1]) }, undef, "can't reparent" );
+	like( $@, qr/cycle/i, 'error about cycles' );
+
+	is( eval { $spaces[0]->reparent($spaces[-5]) }, undef, "can't reparent" );
+	like( $@, qr/cycle/i, 'error about cycles' );
+
+	is( eval { $spaces[11]->reparent($spaces[0]) }, $spaces[11], "reparent 11 under 0" );
+	is( $spaces[11]->parent_count, 1, 'space 11 has one parent now' );
+	is( $spaces[-1]->parent_count, 90, 'space 100 has 90 parents now' );
+};
+
+subtest unproject_space => sub {
+	my $sp1= space->rot_z(.125);
+	my $sp2= $sp1->space->rot_z(.125);
+	my $sp3= $sp2->space->rot_z(.125);
+	my $sp4= $sp3->space->rot_z(.125);
+
+	# Space 4 should be a complete .5 rotation, with X and Y axes pointing opposite direction.
+	my $v= vec3(1,0,0);
+	$_->unproject_inplace($v) for $sp4, $sp3, $sp2, $sp1;
+	is( $v, vec_check(-1,0,0), 'unproject each makes .5 rotation' );
+
+	# Now reparent space 4 to be global
+	$sp4->reparent(undef);
+	is( $sp4->parent_count, 0, 'sp4 has no parents' );
+	# Now unprojecting from sp4 alone should make a .5 rotation.
+	is( $sp4->unproject(vec3(1,0,0)), vec_check(-1,0,0), 'unproject sp4 makes .5 rotation' );
+};
+
+subtest project_space => sub {
+	my $sp1= space->rot(.125, [1,1,1])->tr(5,0,0)->rot_z(.4)->tr(5,4,3);
+	my $sp2= $sp1->space->tr(0,2,1)->rot_z(.2345);
+	# take a second space in global parent space, and project it into sp2
+	my $spb= space->tr(-1,-1,-1)->reparent($sp2);
+	# Now projecting => sp1 => sp2 => spb should result in the same as translating (1,1,1)
+	# no matter what sp1 or sp2 were.
+	my $vec= vec3(2,3,4);
+	$_->project_inplace($vec) for $sp1, $sp2, $spb;
+	is( $vec, vec_check(3,4,5), 'point is offset (1,1,1)' );
+};
+
+subtest reproject_space_via_common_parent => sub {
+	my $sp1= space->rot(.55, [1,2,3])->tr(4,0,4)->space->rot_x(.1);
+	my $sp2= $sp1->space->tr(-1,-1,-1);
+	my $sp3= $sp1->space->space->rot_y(.25);
+	# to take a point from sp3 and translate to sp2 should rotate .25 around Y, then
+	# translate by (1,1,1).
+	my $vec= vec3(1,1,1);
+	$sp3->unproject_inplace($vec);
+	is( $vec, vec_check(1,1,-1) );
+	$sp3->parent->unproject_inplace($vec);
+	is( $vec, vec_check(1,1,-1) );
+	$sp3->parent->parent->unproject_inplace($vec);
+	is( $vec, vec_check(1,1.39680224,-0.22123174) );
+	$sp2->parent->project_inplace($vec);
+	is( $vec, vec_check(1,1,-1) );
+	$sp2->project_inplace($vec);
+	is( $vec, vec_check(2,2,0), 'transform vec the long way' );
+	# now reparent a clone of sp2 into sp3 so that we can just project into that
+	my $sp2_in_sp3= $sp2->clone->reparent($sp3);
+	is( $sp2_in_sp3->project(vec3(1,1,1)), vec_check(2,2,0), 'transform vec the short way' );
+};
+
+done_testing;

--- a/t/06-compat-4x4-pdl.t
+++ b/t/06-compat-4x4-pdl.t
@@ -1,0 +1,35 @@
+use Test2::V0;
+BEGIN {eval {require PDL;1} or skip_all("No PDL")}
+use Math::3Space::PDL 'space', 'vec3';
+
+sub vec_check {
+	my ($x, $y, $z)= @_;
+	return object { call sub { [shift->xyz] }, [ float($x), float($y), float($z) ]; }
+}
+sub mat_check {
+	return [ map float($_), @_ ];
+}
+
+# use OpenGL qw( GL_MODELVIEW_MATRIX glLoadIdentity glTranslatef glGetFloatv_p );
+# use OpenGL::Sandbox "-V1", ":all";
+# make_context; setup_projection; next_frame;
+# glLoadIdentity(); rotate(x => 90); printf("%.5lf\n", $_) for glGetFloatv_p(GL_MODELVIEW_MATRIX);
+subtest get_gl_matrix => sub {
+	my $s= space;
+	is( [ $s->get_gl_matrix ], mat_check(1,0,0,0, 0,1,0,0, 0,0,1,0, 0,0,0,1), 'identity' );
+	$s->get_gl_matrix(my $buf);
+	is( $buf, pack(d16 => (1,0,0,0, 0,1,0,0, 0,0,1,0, 0,0,0,1)), 'identity buffer' );
+
+	$s->translate([ 2,3,4 ]);
+	is( [ $s->get_gl_matrix ], mat_check(1,0,0,0, 0,1,0,0, 0,0,1,0, 2,3,4,1), 'tr 2,3,4' );
+	$s->get_gl_matrix($buf);
+	is( $buf, pack(d16 => (1,0,0,0, 0,1,0,0, 0,0,1,0, 2,3,4,1)), 'tr 2,3,4 buffer' );
+
+	$s= space->rot_x(.25);
+	is( [ $s->get_gl_matrix ], mat_check(1,0,0,0, 0,0,1,0, 0,-1,0,0, 0,0,0,1), 'rot x .25' );
+
+	$s= space->scale(2);
+	is( [ $s->get_gl_matrix ], mat_check(2,0,0,0, 0,2,0,0, 0,0,2,0, 0,0,0,1), 'scale 2' );
+};
+
+done_testing;


### PR DESCRIPTION
As alluded to on #2, here is the PDL implementation. A (very) modest benchmark:

```
Loaded PDL v2.089_01 (supports bad values)

Note: AutoLoader not enabled ('use PDL::AutoLoader' recommended)

pdl> $N = 1e6;
use Math::3Space;
$sp_v = Math::3Space::space();
with_time { @vecs_v = map Math::3Space::Vector::vec3([1,1,1]), 0..$N; };
with_time { $sp_v->project_inplace($_) for @vecs_v };
with_time { $sp_v->project_inplace(@vecs_v) };
723.1 ms
89.656 ms
26.536 ms

pdl> use Math::3Space::PDL;
$sp_pdl = Math::3Space::PDL::space();
with_time { @vecs_pdl = map Math::3Space::PDL::Vector::vec3([1,1,1]), 0..$N };
with_time { $vecs_1pdl = pdl(([1,1,1]) x $N) };
with_time { $sp_pdl->project_inplace($_) for @vecs_pdl };
with_time { $sp_pdl->project_inplace(@vecs_pdl) };
with_time { $sp_pdl->project_inplace($vecs_1pdl) };
5112.42 ms
1239.47 ms
31704.2 ms
18051.5 ms
57.29 ms

pdl> p $vecs_1pdl->info
PDL: Double D [3,1000000]
```

## Commentary

Your code takes 720ms to create 1e6 vectors. It takes 89ms to do `project_inplace` on 1e6 vectors with one call each, but only 26ms when doing them on the Perl stack in one call.

The PDL code takes 5000ms to create one object per vector, though "only" 1200ms to create an ndarray of 3x1e6 numbers. It takes a very long time (31000ms) to do 1e6 vectors with one call each, but that's not really what PDL is for. It's still 18000ms in one call. Using PDL more idiomatically (the last call), it takes 57ms to project 1e6 vectors in one PDL operation.

The last part also demonstrates that this code broadcasts nicely over many vectors just the same as for one.

I expected PDL::LinearAlgebra to make the matrix stuff go quicker, but it either made no difference or actually slowed things down a bit. I expect for larger matrices it would still improve things. When, as I intend to, I make "native" PDL operations to do these 3D tasks in one operation, and use those in the TriD code, that ought to make things here go a bit quicker also.

The tests supplied here are fairly repetitive of your ones, with only the obvious changes at the top (include `skip_all` if PDL not installed). A recommended dependency of PDL seems like a good idea if you do want to merge this.